### PR TITLE
Update dependency install instructions in README.md, and add matplotlib dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It also comes packaged in a Docker image for easy usage.
 Install required packages
 
 ```bash
-python3 -m pip install requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 and start the app:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nicegui>=1.3.0
 odrive>=0.6.2
+matplotlib>=3.7.2


### PR DESCRIPTION
At least for me, when following the instructions on installing the dependencies verbatim, I get the following error:
```
# python3 -m pip install requirements.txt
Defaulting to user installation because normal site-packages is not writeable
ERROR: Could not find a version that satisfies the requirement requirements.txt (from versions: none)
HINT: You are attempting to install a package literally named "requirements.txt" (which cannot exist). Consider using the '-r' flag to install the packages listed in requirements.txt
ERROR: No matching distribution found for requirements.txt
```
Also the matplotlib dependency was missing.