### PR TITLE
Make 'dump errors' button work on older firmwares

### DIFF
--- a/src/controls.py
+++ b/src/controls.py
@@ -39,7 +39,7 @@ def controls(odrv):
         voltage = ui.label()
         ui.timer(1.0, lambda: voltage.set_text(f'{odrv.vbus_voltage:.2f} V'))
         ui.button(on_click=lambda: odrv.save_configuration()).props('icon=save flat round').tooltip('Save configuration')
-        ui.button(on_click=lambda: dump_errors(odrv, True)).props('icon=bug_report flat round').tooltip('Dump errors')
+        ui.button(on_click=lambda: dump_errors(odrv, hasattr(odrv, 'clear_errors'))).props('icon=bug_report flat round').tooltip('Dump and clear errors')
 
     def axis_column(a: int, axis: Any) -> None:
         ui.markdown(f'### Axis {a}')

--- a/src/controls.py
+++ b/src/controls.py
@@ -39,7 +39,8 @@ def controls(odrv):
         voltage = ui.label()
         ui.timer(1.0, lambda: voltage.set_text(f'{odrv.vbus_voltage:.2f} V'))
         ui.button(on_click=lambda: odrv.save_configuration()).props('icon=save flat round').tooltip('Save configuration')
-        ui.button(on_click=lambda: dump_errors(odrv, hasattr(odrv, 'clear_errors'))).props('icon=bug_report flat round').tooltip('Dump and clear errors')
+        ui.button(on_click=lambda: dump_errors(odrv, hasattr(odrv, 'clear_errors'))) \
+            .props('icon=bug_report flat round').tooltip('Dump and clear errors')
 
     def axis_column(a: int, axis: Any) -> None:
         ui.markdown(f'### Axis {a}')


### PR DESCRIPTION
Older firmwares dont have the global `clear_errors()` and calling `dump_errors(odrv, True)`, which internally calls the global `clear_errors()`, on them causes an error. In that case not only are errors not cleared but also the errors don't get dumped.
This modification makes it gracefully degrade to literally just dumping the errors on older firmwares by setting the clear_errors flag only if the odrv structure has the clear_errors member function.

Please do note that I currently don't have any odrive with a firmware that supports the global clear_errors function available to test with myself, so please check that it actually works as intended before merging :)