### PR TITLE
WIP: Feat/multiple odrives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nicegui>=1.3.0
 odrive>=0.6.2
 matplotlib>=3.7.2
+libusb_package>=1.0.26.2

--- a/src/controls.py
+++ b/src/controls.py
@@ -29,8 +29,6 @@ def controls(odrv):
         8: 'loop',
     }
 
-    ui.markdown('## ODrive GUI')
-
     with ui.row().classes('w-full justify-between items-center'):
         with ui.row():
             ui.label(f'SN {hex(odrv.serial_number).removeprefix("0x").upper()}')
@@ -182,6 +180,8 @@ def controls(odrv):
         t_check.bind_value_to(t_plot, 'visible').bind_value_to(t_timer, 'active')
 
     with ui.row():
-        for a, axis in enumerate([odrv.axis0, odrv.axis1]):
+        # hide axi that are not calibrated (they can not be controlled anyway), in favor of possible other odrives
+        enabledAxi = filter(lambda axis: axis.motor.is_calibrated, [odrv.axis0, odrv.axis1])
+        for a, axis in enumerate(enabledAxi):
             with ui.card(), ui.column():
                 axis_column(a, axis)

--- a/src/main.py
+++ b/src/main.py
@@ -2,13 +2,16 @@
 import asyncio
 import functools
 
+import libusb_package
 import odrive
+import usb.util
 from nicegui import app, ui
 
 from controls import controls
 
 ui.colors(primary='#6e93d6')
 
+ui.markdown('## ODrive GUI')
 message = ui.markdown()
 container = ui.column()
 
@@ -17,17 +20,30 @@ def show_message(text: str) -> None:
     message.content = text
     print(text, flush=True)
 
+# List all all connected odrives
+devices = list(libusb_package.find(idVendor=0x1209, idProduct=0x0D32, find_all=True))
+if len(devices) == 0:
+    print("No devices found")
+    exit()
+
+# Get the serials and sort them so that we get a predictable display order
+serials = sorted(list(map(lambda device: usb.util.get_string(device, device.iSerialNumber), devices)))
 
 async def startup() -> None:
-    try:
-        show_message('# Searching for ODrive...')
-        loop = asyncio.get_running_loop()
-        odrv = await loop.run_in_executor(None, functools.partial(odrive.find_any, timeout=15))
+        show_message('# Connecting to ODrives...')
+        odrives = []
+        for serial in serials:
+            try:
+                loop = asyncio.get_running_loop()
+                odrv = await loop.run_in_executor(None, functools.partial(odrive.find_any, serial_number=serial, timeout=15))
+                print("have odrive " + hex(odrv.serial_number))
+                odrives.append(odrv)
+            except TimeoutError:
+                show_message(f'# Could not connect to ODrive {serial}')
         message.visible = False
         with container:
-            controls(odrv)
-    except TimeoutError:
-        show_message('# Could not find any ODrive...')
+            for odrv in odrives:
+                controls(odrv)
 
 app.on_startup(startup)
 

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ ui.colors(primary='#6e93d6')
 
 ui.markdown('## ODrive GUI')
 message = ui.markdown()
-container = ui.column()
+container = ui.row()
 
 
 def show_message(text: str) -> None:
@@ -46,7 +46,8 @@ async def startup() -> None:
         message.visible = False
         with container:
             for odrv in odrives:
-                controls(odrv)
+                with ui.column():
+                    controls(odrv)
 
 app.on_startup(startup)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import functools
+import logging
 
 import libusb_package
 import odrive
@@ -8,6 +9,8 @@ import usb.util
 from nicegui import app, ui
 
 from controls import controls
+
+logging.getLogger("nicegui").setLevel(logging.ERROR)
 
 ui.colors(primary='#6e93d6')
 


### PR DESCRIPTION
With this PR the GUI can support multiple connected odrives.

Weirdly the odrive library API does not provide a straight-forward way to simply find all odrives; the best thing it allows us to do  is keep trying to discover more until that times out (even that would require hooking into the discovery internals).
This means that app startup would always be delayed by the timeout period, which would be very unpleasant.
Repeatedly calling `odrive.find_any()` and hoping it will return all connected drives one by one also does not work: it arbitrarily returns previously discovered odrives even if other undiscovered ones are available.

Instead I solved the problem here by using a generic USB interface to find the serial numbers of all connected odrives and then using `odrive.find_any` with the given serial numbers to connect the drives one by one. This does introduce an additional dependency, namely libusb_package. I hope that this is accetable.
I could have opted to use pyusb directly but that requires the user to make sure they have the right system-level libraries installed. libusb_package is basically a wrapper for pyusb that takes care of the system-level dependencies, making things easier for the end-user.