### PR TITLE
Dynamic device discovery + support multiple ODrives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 nicegui>=1.3.13
 odrive>=0.6.2
 matplotlib>=3.7.2
-libusb_package>=1.0.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nicegui>=1.3.0
+nicegui>=1.3.13
 odrive>=0.6.2
 matplotlib>=3.7.2
 libusb_package>=1.0.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nicegui>=1.3.0
 odrive>=0.6.2
 matplotlib>=3.7.2
+libusb_package>=1.0.26.2

--- a/src/controls.py
+++ b/src/controls.py
@@ -29,8 +29,6 @@ def controls(odrv):
         8: 'loop',
     }
 
-    ui.markdown('## ODrive GUI')
-
     with ui.row().classes('w-full justify-between items-center'):
         with ui.row():
             ui.label(f'SN {hex(odrv.serial_number).removeprefix("0x").upper()}')
@@ -182,6 +180,8 @@ def controls(odrv):
         t_check.bind_value_to(t_plot, 'visible').bind_value_to(t_timer, 'active')
 
     with ui.row():
-        for a, axis in enumerate([odrv.axis0, odrv.axis1]):
+        # hide axi that are not calibrated (they can not be controlled anyway), in favor of possible other odrives
+        enabledAxi = filter(lambda axis: axis.motor.is_calibrated, [odrv.axis0, odrv.axis1])
+        for a, axis in enumerate(enabledAxi):
             with ui.card(), ui.column():
                 axis_column(a, axis)

--- a/src/controls.py
+++ b/src/controls.py
@@ -29,6 +29,15 @@ def controls(odrv):
         8: 'loop',
     }
 
+    def reboot():
+        try:
+            odrv.reboot()
+        except Exception as err:
+            if (type(err).__name__ == "ObjectLostError"):
+                pass
+            else:
+                raise err
+
     with ui.row().classes('w-full justify-between items-center'):
         with ui.row():
             ui.label(f'SN {hex(odrv.serial_number).removeprefix("0x").upper()}')
@@ -44,6 +53,9 @@ def controls(odrv):
             ui.button(on_click=lambda: dump_errors(odrv, hasattr(odrv, 'clear_errors'))) \
                 .props('icon=bug_report flat round') \
                 .tooltip('Dump and clear errors')
+            ui.button(on_click=reboot) \
+                .props('icon=restart_alt flat round') \
+                .tooltip('Reboot odrive')
 
     def axis_column(a: int, axis: Any) -> None:
         ui.markdown(f'### Axis {a}')

--- a/src/controls.py
+++ b/src/controls.py
@@ -33,8 +33,11 @@ def controls(odrv):
     def reboot():
         try:
             odrv.reboot()
-        except fibre.ObjectLostError:
-            pass
+        except Exception as err:
+            if type(err).__name__ == 'ObjectLostError':
+                pass
+            else:
+                raise err
 
     with ui.row().classes('w-full justify-between items-center'):
         with ui.row():

--- a/src/main.py
+++ b/src/main.py
@@ -2,13 +2,16 @@
 import asyncio
 import functools
 
+import libusb_package
 import odrive
+import usb.util
 from nicegui import app, ui
 
 from controls import controls
 
 ui.colors(primary='#6e93d6')
 
+ui.markdown('## ODrive GUI')
 message = ui.markdown()
 container = ui.column()
 
@@ -17,17 +20,30 @@ def show_message(text: str) -> None:
     message.content = text
     print(text, flush=True)
 
+# List all all connected odrives
+devices = list(libusb_package.find(idVendor=0x1209, idProduct=0x0D32, find_all=True))
+if len(devices) == 0:
+    print("No devices found")
+    exit()
+
+# Get the serials and sort them so that we get a predictable display order
+serials = sorted(list(map(lambda device: usb.util.get_string(device, device.iSerialNumber), devices)))
 
 async def startup() -> None:
-    try:
-        show_message('# Searching for ODrive...')
-        loop = asyncio.get_running_loop()
-        odrv = await loop.run_in_executor(None, functools.partial(odrive.find_any, timeout=15))
+        show_message('# Connecting to ODrives...')
+        odrives = []
+        for serial in serials:
+            try:
+                loop = asyncio.get_running_loop()
+                odrv = await loop.run_in_executor(None, functools.partial(odrive.find_any, serial_number=serial, timeout=15))
+                print("have odrive " + hex(odrv.serial_number))
+                odrives.append(odrv)
+            except TimeoutError:
+                show_message(f'# Could not connect to ODrive {serial}')
         message.visible = False
         with container:
-            controls(odrv)
-    except TimeoutError:
-        show_message('# Could not find any ODrive...')
+            for odrv in odrives:
+                controls(odrv)
 
 app.on_startup(startup)
 

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ ui.colors(primary='#6e93d6')
 
 ui.markdown('## ODrive GUI')
 message = ui.markdown()
-container = ui.column()
+container = ui.row()
 
 
 def show_message(text: str) -> None:
@@ -46,7 +46,8 @@ async def startup() -> None:
         message.visible = False
         with container:
             for odrv in odrives:
-                controls(odrv)
+                with ui.column():
+                    controls(odrv)
 
 app.on_startup(startup)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import functools
+import logging
 
 import libusb_package
 import odrive
@@ -8,6 +9,8 @@ import usb.util
 from nicegui import app, ui
 
 from controls import controls
+
+logging.getLogger("nicegui").setLevel(logging.ERROR)
 
 ui.colors(primary='#6e93d6')
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,56 +7,33 @@ from nicegui import app, ui
 
 from controls import controls
 
-logging.getLogger("nicegui").setLevel(logging.ERROR)
+logging.getLogger('nicegui').setLevel(logging.ERROR)
 
 ui.colors(primary='#6e93d6')
 
+devices: dict[int, ui.element] = {}
+
 ui.markdown('## ODrive GUI')
-message = ui.markdown()
+ui.markdown('Waiting for ODrive devices to connect...').bind_visibility_from(globals(), 'devices', lambda d: not d)
 container = ui.row()
 
 
-def show_message(text: str) -> None:
-    message.content = text
-    print(text, flush=True)
-
-known_devices = {}
-active_devices = {}
-
-async def discovery_loop():
-    show_message('# Connecting to ODrives...')
+async def discovery_loop() -> None:
     odrive.start_discovery(odrive.default_usb_search_path)
     while True:
-        signal = odrive.connected_devices_changed
-        if len(odrive.connected_devices) > len(known_devices):
-            # A device is connected for which no controller is currently active
-            device = odrive.connected_devices[-1]
-            serial = hex(device.serial_number)
-            print(f'Adding ODrive {serial}')
-            with container:
-                with ui.column() as element:
-                    controls(device)
-            known_devices[serial] = element
-            # Move it to the correct position
-            ordered_devices = sorted(list(known_devices.keys()))
-            target_index = ordered_devices.index(serial)
-            element.move(target_index=target_index)
-            message.visible = False
-        elif len(odrive.connected_devices) < len(known_devices):
-            # a device for which we're rendering an active controller is not connected anymore
-            # find out which one
-            remaining_serials = remaining_serials = [hex(device.serial_number) for device in odrive.connected_devices]
-            lost_serials = [serial_number for serial_number in known_devices if serial_number not in remaining_serials]
-            # deactivate the controllers for the lost devices
-            for lost_serial in lost_serials:
-                print(f'Removing ODrive {lost_serial}')
-                container.remove(known_devices[lost_serial])
-                del known_devices[lost_serial]
-        await asyncio.wrap_future(signal)
+        for device in odrive.connected_devices:
+            if device.serial_number not in devices:
+                print(f'Adding ODrive {device.serial_number:x}')
+                with container:
+                    with ui.column() as devices[device.serial_number]:
+                        controls(device)
+        for serial_number in list(devices):
+            if not any(d.serial_number == serial_number for d in odrive.connected_devices):
+                print(f'Removing ODrive {serial_number:x}')
+                container.remove(devices.pop(serial_number))
+        await asyncio.wrap_future(odrive.connected_devices_changed)
 
-async def startup() -> None:
-        asyncio.create_task(discovery_loop())
 
-app.on_startup(startup)
+app.on_startup(discovery_loop())
 
 ui.run(title='ODrive Motor Tuning')


### PR DESCRIPTION
This supports dynamic discovery of ODrives (ie devices connecting/disconnecting/reconnecting/rebooting while the program is running). It also adds support for interfacing with multiple ODrives simultaneously and adds a reboot button per ODrive.

This builds upon (but pretty much re-does) #9 
This fixes #4 
